### PR TITLE
Improve generation script

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -43,7 +43,7 @@ jobs:
         continue-on-error: true
         run: |
             git checkout -b $BRANCH_NAME
-            [[ $(git diff --name-only) == "src/connectors/mod.ts" ]] && { echo "No real changes. Do not commit."; exit 1; }
+            [[ $(git ls-files --other --modified --exclude-standard) == "src/connectors/mod.ts" ]] && { echo "No real changes. Do not commit."; exit 1; }
             git add --all
             git commit -m "Automated commit: Latest generated changes from schedule action"
 


### PR DESCRIPTION
## Summary

This PR aims to improve the generation script by providing a more stable command to look up changed file after generating the typescript files. 

In the last [scheduled generation ](https://github.com/slackapi/deno-slack-hub/actions/runs/6140254073) the script was unable to recognize that their were more then one changed files and did not created a PR for the generated files.

Testing:

1. Pull this repo
2. Make a change in `src/connectors/mod.ts`
3. run the following `sh` command `[[ $(git ls-files --other --modified --exclude-standard) == "src/connectors/mod.ts" ]] && { echo "No real changes. Do not commit."; exit 1; }` -- the output should "No real changes. Do not commit."
4. Make a change in another file in the repo
5.  run the following `sh` command `[[ $(git ls-files --other --modified --exclude-standard) == "src/connectors/mod.ts" ]] && { echo "No real changes. Do not commit."; exit 1; }` -- their should be no output

[This generation](https://github.com/slackapi/deno-slack-hub/actions/runs/6150740176) GitHub action was triggered from this branch and shows that the changes work.


## Requirements

- [x] I've read and understood the
      [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md)
      and have done my best effort to follow them.
- [x] I've read and agree to the
      [Code of Conduct](https://slackhq.github.io/code-of-conduct).
