### PR TITLE
fix: remove versioning disclaimer

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -20,9 +20,6 @@ Slack.
 
 ## Versioning
 
-**Disclaimer**: prior to the release of `1.x.x` this package is considered
-unstable and will not adhere to [Semantic Versioning](http://semver.org/)
-
 Releases for this repository follow the [SemVer](https://semver.org/) versioning
 scheme. The HUB's contract is determined by the top-level exports from
 `src/mod.ts` and `src/types.ts`. Exports not included in these files are deemed


### PR DESCRIPTION
## Summary

This PR removed the versioning disclaimer, moving forwards this project will follow SemVer

## Requirements

<!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the
      [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md)
      and have done my best effort to follow them.
- [x] I've read and agree to the
      [Code of Conduct](https://slackhq.github.io/code-of-conduct).
