### PR TITLE
feat: support deno version 2.x

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -2,9 +2,9 @@ name: Deno
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   deno:
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # we test on both most recent stable version of deno (v1.x) as well as
         # the version of deno used by Run on Slack (v1.31.1)
-        deno-version: [v1.x, v1.31.1]
+        deno-version: [v1.x, v2.x]
 
     steps:
       - name: Setup repo
@@ -31,7 +31,7 @@ jobs:
         run: deno task coverage
 
       - name: Upload coverage to CodeCov
-        if: ${{ matrix.deno-version == 'v1.x' }}
+        if: ${{ matrix.deno-version == 'v2.x' }}
         uses: codecov/codecov-action@v5.4.0
         with:
           files: ./lcov.info

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -14,6 +14,7 @@ jobs:
         # we test on both most recent stable version of deno (v2.x) as well as
         # the version of deno used by Run on Slack (v1.46.2)
         deno-version:
+          - v1.x
           - v1.46.2
           - v2.x
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # we test on both most recent stable version of deno (v1.x) as well as
-        # the version of deno used by Run on Slack (v1.31.1)
+        # the version of deno used by Run on Slack
         deno-version: [v1.x, v2.x]
 
     steps:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # we test on both most recent stable version of deno (v1.x) as well as
-        # the version of deno used by Run on Slack
+        # we test on both most recent stable version of deno (v2.x) as well as
+        # the version of deno used by Run on Slack (v1.46.2)
         deno-version:
-          - v1.x
+          - v1.46.2
           - v2.x
 
     steps:

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,28 +1,20 @@
 {
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "fmt": {
-    "files": {
-      "include": ["src", "README.md", "scripts", ".github", "deno.jsonc"]
-    },
-    "options": {
-      "semiColons": true,
-      "indentWidth": 2,
-      "lineWidth": 80,
-      "proseWrap": "always",
-      "singleQuote": false,
-      "useTabs": false
-    }
+    "include": ["src", "README.md", "scripts", ".github", "deno.jsonc"],
+    "semiColons": true,
+    "indentWidth": 2,
+    "lineWidth": 80,
+    "proseWrap": "always",
+    "singleQuote": false,
+    "useTabs": false
   },
   "lint": {
-    "files": {
-      "include": ["src", "scripts"],
-      "exclude": ["**/*.md"]
-    }
+    "include": ["src", "scripts"],
+    "exclude": ["**/*.md"]
   },
   "test": {
-    "files": {
-      "include": ["src", "scripts"]
-    }
+    "include": ["src", "scripts"]
   },
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test --allow-read",

--- a/scripts/src/dev_deps.ts
+++ b/scripts/src/dev_deps.ts
@@ -10,5 +10,5 @@ export { assert } from "https://deno.land/x/conditional_type_checks@1.0.6/mod.ts
 export type {
   IsExact,
 } from "https://deno.land/x/conditional_type_checks@1.0.6/mod.ts";
-export * as MockFetch from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
+export { stub } from "jsr:@std/testing/mock";
 export { isHttpError } from "https://deno.land/std@0.182.0/http/http_errors.ts";


### PR DESCRIPTION
## Summary

This PR aims to move one step closer to supporting Deno 2.x 🚀 

It adapts the CI pipeline to tests against Deno 2.x, unfortunately Deno 2.x does not like the [mock_fetch](https://deno.land/x/mock_fetch@0.3.0) library used to stub the fetch library in the projects unit tests. 

```sh
error: Requires import access to "crux.land:443", run again with the --allow-import flag
    at https://deno.land/x/mock_fetch@0.3.0/mod.ts:1:46
```

These changes remove the [mock_fetch](https://deno.land/x/mock_fetch@0.3.0) dependence in favor of directly stubing the fetch library 🪓 

## Requirements

<!-- place an `x` in each `[ ]` -->

- [x] I've read and understood the
      [Contributing Guidelines](https://github.com/slackapi/deno-slack-sdk/blob/main/.github/CONTRIBUTING.md)
      and have done my best effort to follow them.
- [x] I've read and agree to the
      [Code of Conduct](https://slackhq.github.io/code-of-conduct).
